### PR TITLE
feat: week 3 patch

### DIFF
--- a/src/bin/data_types.rs
+++ b/src/bin/data_types.rs
@@ -43,7 +43,7 @@
 ///
 /// Rust also incorporates a `bool` type for Boolean values, which can either
 /// be `true` or `false`. Conditional expressions such as `if` and `while`
-/// necessitate a `bool` value.
+/// necessitate a `bool` value. 1 and 0 are not considered `true` and `false`.
 ///
 /// ```rust
 /// let t: bool = true;
@@ -97,7 +97,7 @@
 /// The prohibition of implicit conversion between different types is a design
 /// decision in Rust aimed at preventing bugs. This requirement encourages
 /// careful consideration of potential truncation, overflow, or loss of
-/// precision when converting between types.
+/// precision when casting between types. 
 ///
 /// When casting between integer types using `as`, Rust performs truncations
 /// and/or sign extensions. For instance, converting from `u8` to `i32` pads
@@ -106,6 +106,9 @@
 ///
 /// When casting between float and integer types, Rust performs rounding
 /// towards zero. The complete rules can be found in [the Rust Reference].
+/// 
+/// Cast is only allowed between certain primitive types. For more complex type 
+/// conversions, we'll cover them later.
 ///
 /// ### Quiz
 ///

--- a/src/bin/data_types_2.rs
+++ b/src/bin/data_types_2.rs
@@ -19,6 +19,9 @@
 /// let ch = '🦀'; // Emoji
 /// ```
 ///
+/// Rust also guarantees that a `char` is a valid Unicode scalar value at compiler
+/// level.
+/// 
 /// Contrarily, Rust strings are not simply arrays of characters. They are
 /// represented as UTF-8 encoded bytes, enhancing memory efficiency and
 /// compatibility with byte-oriented systems. UTF-8 is a variable-width
@@ -58,13 +61,17 @@
 ///
 /// String literals are written using double quotes, resulting in a value of
 /// type `&str`. A `&str` can be converted into a `String` by invoking the
-/// `to_string` method. For example:
+/// `to_string` method. This would involve heap allocation and copying.
+///  For example:
 ///
 /// ```
 /// let s: &str = "Hello"; // A string literal
 /// let s: String = "Hello".to_string(); // A string literal converted to a String
 /// ```
-///
+/// 
+/// Rust also has multiline string literals, you may check them out in the 
+/// [Raw Literals in Rust Reference].
+/// 
 /// To obtain a `&str` from a `String`, you can either slice the `String` or
 /// use the `as_str` method to fetch a reference to the entire string, as shown
 /// below:
@@ -80,12 +87,28 @@
 ///
 /// In the above examples, `1..` signifies the range from the first byte to the
 /// string's end. Since slicing operates at the byte level, the slicing
-/// position must align with a character boundary; otherwise, an error will
-/// occur.
+/// position must align with a character boundary; otherwise, it will result in
+/// a panic. If you don't want to panic, you can use the `str::get` method to
+/// slice the string, getting a `None` if there's any boundary error.
+/// 
+/// ```
+/// let s: String = "Hello".to_string();
+/// let s: Option<&str> = s.get(1..); // Using the get method
+/// assert_eq!(s, Some("ello"));
+/// ```
 ///
 /// The `&` operator is utilized to fetch a reference to a value. We will delve
-/// into this operator in more depth in subsequent discussions.
+/// into this operator in more depth in subsequent discussions. 
+/// 
+/// You may wonder what is a `str` compared to `&str`. The `str` is a type that
+/// you cannot build a corresponding value by hand, but can be used to construct
+/// other types. We'll ignore it for now.
 ///
+/// You may also wonder why we can call the `get` method on a `String`, which is
+/// not a `str`. There are indeed some sneaky implicit type conversions going on!
+/// We'll discuss this in more detail in the future, but for now, you can safely call
+/// any method that is defined for `str` on a `String`.
+/// 
 /// ### Quiz: "NOT yes!"
 ///
 /// The "yes" command is a fascinating command-line utility that perpetually
@@ -134,6 +157,8 @@
 ///     println!("{}", result);
 /// }
 /// ```
+/// 
+/// [Raw Literals in Rust Reference]: https://doc.rust-lang.org/reference/tokens.html#raw-string-literals
 ///
 fn quiz() {
     let mut result = String::new();

--- a/src/bin/data_types_2.rs
+++ b/src/bin/data_types_2.rs
@@ -50,7 +50,7 @@
 /// assert_eq!(s.chars().nth(0), Some('你')); // Indexing at the character level
 /// ```
 ///
-/// Rust provides two primary types for handling strings: `&str` and `String`.
+/// Rust provides two types for handling strings: `&str` and `String`.
 /// The `&str` type corresponds to an immutable reference to a string slice,
 /// while `String` denotes a growable, heap-allocated string. For those
 /// familiar with C++, `&str` is similar to `const char*`, and `String` is

--- a/src/bin/mutable_and_shadowing.rs
+++ b/src/bin/mutable_and_shadowing.rs
@@ -100,8 +100,30 @@
 /// ```
 ///
 /// Functions that may mutate their arguments necessitate those arguments to be
-/// declared as mutable. Fortunately, Rust's compiler will remind you to
-/// declare a mutable variable when necessary, preventing potential oversights.
+/// declared as mutable. Notice that by adding the `mut` keyword to the
+/// function's formal argument, the function can now assign a new value to the
+/// formal argument, but won't be able to modify the actual argument in the caller.
+/// Do not confuse this with a mutable reference `&mut T`!
+///
+/// ```rust
+/// fn add_one(mut x: i32) -> i32 {
+///   //       ^^^
+///   x += 1; // Adding `mut` enables us to modify `x`
+///   x
+/// }
+///
+/// fn main() {
+///   let x = 1;
+///   let y = add_one(x);
+///   assert_eq!(x, 1); // x is unchanged!
+/// }
+/// ```
+///
+/// Fortunately, Rust's compiler will remind you to change a variable to mutable
+/// when necessary, or change an untouched mutable variable to an immutable one,
+/// preventing potential oversights. However it's worth noting that changing the
+/// variable's mutability *won't* change the variable's type, unlike `const`
+/// in C++.
 ///
 /// Mutability is a crucial aspect of Rust's memory model. The discussion here
 /// merely scratches the surface of this concept, and there's much more to

--- a/src/bin/references.rs
+++ b/src/bin/references.rs
@@ -1,0 +1,131 @@
+//! References and Borrowing in Rust
+//! See also: [References and Borrowing in the Rust Book](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html)
+
+/// ### References
+/// 
+/// If you came from C++, you might have heard of references. However, the
+/// concept of references in Rust is *very different* from C++. In C++, a 
+/// reference is somewhat *an alias* to the variable. Notice that in the 
+/// following C++ code, when you pass `a` to a reference `b`, `b` will become
+///  an alias to it. You can use `b` as if it's of type `T` , without having
+///  to write `b->push_back`.
+///
+/// ```c++
+/// std::vector<int> a{1, 2, 3};
+/// std::vector<int> &b = a; // A C++ reference to a variable
+/// b.push_back(4); // You can use C++ reference type `T&` just like `T`
+/// ```
+///
+/// Under the hood, C++ references are pointers, but they are used like normal
+/// variables, that's why they are treated as aliases.
+///
+/// References in Rust are different. You may call them *safe pointers*. 
+/// Use **borrow operator** `&` (the address-of operator in C) to get a reference.
+///
+/// ```
+/// let x: usize = 1;
+/// let y: &usize = &x; // You cannot write `x` here!
+/// ```
+///
+/// References to `T` are of their own type `&T`, just like C++ pointers.
+///
+/// ```
+/// fn ref_is_a_type(x: &usize) { /* ... */ }
+/// 
+/// let x = 114514;
+/// ref_is_a_type(&a); // OK
+/// ref_is_a_type(a);  // ! Compiler Error: Mismatched type!
+/// ```
+/// 
+/// The `&mut` operator will give you a mutable reference, which allows
+/// you to modify the address it points to through it. The mutable
+/// reference `&mut T` is like the normal C pointer, while the immutable
+/// reference `&T` (also called shared reference) is like the pointer
+/// version of C++ `const T&`.
+///
+/// Deref operator `*` is `&`'s counterpart.
+///
+/// ### Borrowing
+///
+/// Instead of 'getting address of', Rust uses 'borrowing' to describe
+/// the `&`. A reference doesn't take away the original value's ownership,
+/// but uses it temporarily, and guarantees a 'return' after use. 
+///
+/// ```
+/// let owner = String::from("Hello, world!");
+/// let reference = &owner;
+/// drop(*reference); // ! Compiler Error: Cannot move out of reference
+/// ```
+/// 
+/// Rust compiler also enforces a reader-writer lock rule on reference
+/// (with no runtime cost). Within any scope, you can either
+///
+/// 1. Have *any number of* immutable references.
+/// 2. Have *only one* mutable reference.
+///
+/// You may wonder why we need to prevent data races if we are not
+/// concerned about concurrent programming. Consider the following
+/// situation. If you push an element to the back of a `Vec` through
+/// a mutable reference `a`, but there's an immutable reference `b`
+/// pointing to the first element at the same time. What would you get
+/// when you read from `b`, if the `Vec` grows and moved to a new place?
+/// 
+/// As a *safe* pointer, references are guaranteed to be valid, if you
+/// are not playing with `unsafe` stuff. You won't access illegal memory
+/// when using it. The tradeoff is that you have to follow some rules.
+/// Besides the borrowing rules, Rust also have lifetime rules to ensure
+/// this. We'll (definitely) look into lifetimes later.
+///
+/// ### Quiz
+///
+/// Fix the code below to make it compile and pass the tests. Use shadowing and
+/// mutability.
+///
+/// ```no_run
+/// fn quiz() {
+///     let x = 1; // FIX ME
+///     assert_eq!(x, 1);
+///     
+///     x = 2;
+///     assert_eq!(x, 2);
+///     
+///     x = "hello".to_string(); // FIX ME
+///     x.push_str(", world!");
+///     assert_eq!(x, "hello, world!");
+/// }
+/// ```
+#[allow(unused)]
+fn main() {
+    let vec: Vec<_> = vec!["Rust", "is", "the", "Genshin", "Impact", "of", "programming", "languages", "but", "if", "you", "learn", "it", "well", "it", "feels", "like", "Saizeriya"].into_iter().map(String::from).collect();
+
+    fn this_is_t(t: String) -> String { t }
+    fn this_is_ref(r: &String) -> &String { r }
+    fn this_is_mut_ref(r: &mut String) -> &mut String { r }
+
+    /*
+        Guide: Fix the code below to make it compile.
+
+        DO NOT REORDER any line in the following code.
+
+        Fix errors in the following order:
+        1. Check the function signatures and fix function and macro calls. Add `mut`, `&`, `&mut` where necessary. Do not change the `in vec` part. 
+        2. Solve compiler error E0382. The compiler will suggest something for you. Consider ownership rules and reason why the solution works.
+        3. Solve compiler error E0502 by commenting out one line of the `assert_eq!`. Consider borrowing rules and reason why commenting out that line works.
+     */
+
+    for word // FIX ME           
+    in vec {
+        let t = {
+            this_is_t(word) // FIX ME
+        };
+        let r = {
+            this_is_ref(word) // FIX ME
+        };
+        let r_mut = {
+            this_is_mut_ref(word) // FIX ME
+        };
+
+        assert_eq!(t, r); // FIX ME
+        assert_eq!(t, r_mut); // FIX ME
+    }
+}


### PR DESCRIPTION
略微改动了第三周的几处，主要是简单提了一嘴 `&str` 和 `String` 的 `Deref` 关系，但没提到 `Deref` trait 本身。因为使用`String` 的时候可能会用到 `str` 的方法（同理包括 `&[]` 和 `Vec`），可能造成一些困扰？
